### PR TITLE
[FEAT] Add swagger DTO annotations

### DIFF
--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,10 +1,19 @@
+import { ApiProperty } from "@nestjs/swagger";
 import { IsEmail, IsNotEmpty, IsString } from "class-validator";
 
 export class LoginDto {
+  @ApiProperty({
+    description: "User email address",
+    example: "john.doe@example.com",
+  })
   @IsNotEmpty()
   @IsEmail()
   email: string;
 
+  @ApiProperty({
+    description: "User password",
+    example: "password123",
+  })
   @IsNotEmpty()
   @IsString()
   password: string;

--- a/src/films/dto/film.dto.ts
+++ b/src/films/dto/film.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsString,
 } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
 
 export type FilmDto = {
   _id: string;
@@ -24,58 +25,141 @@ export type FilmDto = {
 };
 
 export class CreateFilmDto {
+  @ApiProperty({
+    description: "Title of the film",
+    example: "Star Wars: A New Hope",
+  })
   @IsNotEmpty()
   @IsString()
   title: string;
 
+  @ApiProperty({
+    description: "Release date of the film in ISO format",
+    example: "1977-05-25",
+  })
+  @IsNotEmpty()
   @IsDateString()
-  @IsString()
   releaseDate: string;
 
+  @ApiProperty({
+    description: "URL of the film resource",
+    example: "https://swapi.dev/api/films/1/",
+    required: false,
+  })
   @IsOptional()
   @IsString()
   url?: string;
 
+  @ApiProperty({
+    description: "Episode ID of the film",
+    example: 4,
+    required: false,
+  })
   @IsOptional()
   @IsString()
   episodeId?: number;
 
+  @ApiProperty({
+    description: "Director of the film",
+    example: "George Lucas",
+    required: false,
+  })
   @IsOptional()
   @IsString()
   director?: string;
 
+  @ApiProperty({
+    description: "Producer(s) of the film",
+    example: "Gary Kurtz, Rick McCallum",
+    required: false,
+  })
   @IsOptional()
   @IsString()
   producer?: string;
 
+  @ApiProperty({
+    description: "Opening crawl text of the film",
+    example: "It is a period of civil war...",
+    required: false,
+  })
   @IsOptional()
   @IsString()
   openingCrawl?: string;
 
+  @ApiProperty({
+    description: "Array of character URLs",
+    example: [
+      "https://swapi.dev/api/people/1/",
+      "https://swapi.dev/api/people/2/",
+    ],
+    required: false,
+  })
   @IsOptional()
-  @IsString()
+  @IsString({ each: true })
   characters?: string[];
 
+  @ApiProperty({
+    description: "Array of planet URLs",
+    example: [
+      "https://swapi.dev/api/planets/1/",
+      "https://swapi.dev/api/planets/2/",
+    ],
+    required: false,
+  })
   @IsOptional()
-  @IsString()
+  @IsString({ each: true })
   planets?: string[];
 
+  @ApiProperty({
+    description: "Array of starship URLs",
+    example: [
+      "https://swapi.dev/api/starships/1/",
+      "https://swapi.dev/api/starships/2/",
+    ],
+    required: false,
+  })
   @IsOptional()
-  @IsString()
+  @IsString({ each: true })
   starships?: string[];
 
+  @ApiProperty({
+    description: "Array of vehicle URLs",
+    example: [
+      "https://swapi.dev/api/vehicles/1/",
+      "https://swapi.dev/api/vehicles/2/",
+    ],
+    required: false,
+  })
   @IsOptional()
-  @IsString()
+  @IsString({ each: true })
   vehicles?: string[];
 
+  @ApiProperty({
+    description: "Array of species URLs",
+    example: [
+      "https://swapi.dev/api/species/1/",
+      "https://swapi.dev/api/species/2/",
+    ],
+    required: false,
+  })
   @IsOptional()
-  @IsString()
+  @IsString({ each: true })
   species?: string[];
 
+  @ApiProperty({
+    description: "Creation timestamp",
+    example: "2024-01-01T12:00:00Z",
+    required: false,
+  })
   @IsOptional()
   @IsString()
   created?: string;
 
+  @ApiProperty({
+    description: "Last edited timestamp",
+    example: "2024-01-02T12:00:00Z",
+    required: false,
+  })
   @IsOptional()
   @IsString()
   edited?: string;

--- a/src/users/dto/user.dto.ts
+++ b/src/users/dto/user.dto.ts
@@ -1,17 +1,35 @@
-import { OmitType } from "@nestjs/swagger";
+import { ApiProperty, OmitType } from "@nestjs/swagger";
 import { IsEmail, IsNotEmpty, IsString, MinLength } from "class-validator";
 
 export class CreateUserDto {
+  @ApiProperty({
+    description: "User first name",
+    example: "John",
+    required: false,
+  })
   @IsString()
   firstName: string;
 
+  @ApiProperty({
+    description: "User last name",
+    example: "doe",
+    required: false,
+  })
   @IsString()
   lastName: string;
 
+  @ApiProperty({
+    description: "User email address",
+    example: "john.doe@example.com",
+  })
   @IsNotEmpty()
   @IsEmail()
   email: string;
 
+  @ApiProperty({
+    description: "User password",
+    example: "password123",
+  })
   @IsNotEmpty()
   @IsString()
   @MinLength(6)


### PR DESCRIPTION
This pull request includes changes to add Swagger API documentation to various DTO (Data Transfer Object) classes in the project. The most important changes involve adding the `@ApiProperty` decorator to provide metadata for the Swagger documentation.

Enhancements to DTO classes for Swagger documentation:

* [`src/auth/dto/login.dto.ts`](diffhunk://#diff-e697f2e0c38a6a2b8422e36885fa1ed10fd6dd437e22f7e066ef00a97fe36a66R1-R16): Added `@ApiProperty` decorators to the `email` and `password` fields to include descriptions and example values.
* [`src/films/dto/film.dto.ts`](diffhunk://#diff-cdff0f35f5e9503a5a779db6bb3347aa142da17523f991059dc35ad954672f0dR7): Added `@ApiProperty` decorators to multiple fields in the `CreateFilmDto` class to provide descriptions, example values, and indicate optional properties. [[1]](diffhunk://#diff-cdff0f35f5e9503a5a779db6bb3347aa142da17523f991059dc35ad954672f0dR7) [[2]](diffhunk://#diff-cdff0f35f5e9503a5a779db6bb3347aa142da17523f991059dc35ad954672f0dR28-R162)
* [`src/users/dto/user.dto.ts`](diffhunk://#diff-f2ba468830e34d64a69990e5e0219601e3b9db35f999706951c89534c7ba52c2L1-R32): Added `@ApiProperty` decorators to the `firstName`, `lastName`, `email`, and `password` fields in the `CreateUserDto` class to include descriptions, example values, and indicate required fields.